### PR TITLE
fix: Remove X-API-KEY header duplication

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -56,10 +56,6 @@ func NewClient(endpoint, apiKey *string) (*ApiClient, error) {
 }
 
 func (c *ApiClient) doRequest(req *http.Request) ([]byte, error) {
-	key := c.APIKey
-
-	req.Header.Set("X-API-KEY", key)
-
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
By calling the `req.Header.Set("X-API-KEY", key)`, the library is sending the authentication header as an array of values, and the APISIX Admin API was not accepting it. The duplication on the header value happens because after the `req.Header.Set(...)`, the code also calls `r.Header.Add(k, v);` on the `RoundTrip` function.

This is related to an issue on the APISIX Terraform provider https://github.com/rework-space-com/terraform-provider-apisix/issues/20