### PR TITLE
chore: Create UpstreamTLS object

### DIFF
--- a/upstream.go
+++ b/upstream.go
@@ -25,7 +25,7 @@ type Upstream struct {
 	HashOn          *string                    `json:"hash_on,omitempty"`
 	Key             *string                    `json:"key,omitempty"`
 	KeepalivePool   *UpstreamKeepAlivePoolType `json:"keepalive_pool,omitempty"`
-	TLSClientCertID *string                    `json:"tls.client_cert_id,omitempty"`
+	TLSClientCertID *UpstreamTLS               `json:"tls,omitempty"`
 	Checks          *UpstreamChecksType        `json:"checks,omitempty"`
 	Nodes           *[]UpstreamNodeType        `json:"nodes,omitempty"`
 }
@@ -40,6 +40,10 @@ type UpstreamKeepAlivePoolType struct {
 	Size        int64 `json:"size"`
 	IdleTimeout int64 `json:"idle_timeout"`
 	Requests    int64 `json:"requests"`
+}
+
+type UpstreamTLS struct {
+	ClientCertID string `json:"client_cert_id"`
 }
 
 type UpstreamChecksType struct {


### PR DESCRIPTION
👋 

I'm using the [APISIX Terraform provider](https://github.com/rework-space-com/terraform-provider-apisix) and encountered an issue when trying to configure an upstream with the [tls_client_cert_id](https://registry.terraform.io/providers/rework-space-com/apisix/latest/docs/resources/upstream#tls_client_cert_id-5) field.

### Problem

When applying, I receive the following error:
```
Could not update upstream, unexpected error: status: 400, body: {"error_msg":"invalid configuration: additional properties forbidden, found tls.client_cert_id"}
```

I was able to reproduce this by directly calling the APISIX Admin API. Sending:
```
{
  "tls.client_cert_id": "foo"
}
```
results in the same 400 error, whereas the following works as expected:
```
{
  "tls": {
    "client_cert_id": "bar"
  }
} 
```

It looks like this is due to how Go's standard JSON encoder works — it doesn’t support inlined nested JSON keys by default ([golang/go#27366](https://github.com/golang/go/issues/27366)).

### Solution

To fix this, I introduced a dummy UpstreamTLS object to properly structure the tls.client_cert_id field.

Let me know if this approach makes sense or if there's a better way you'd suggest.

Thanks!

Disclaimer: This is my first Go contribution, happy to receive feedback 😊